### PR TITLE
fix: reverse editor placeholder commit for ux

### DIFF
--- a/src/components/outlines/editor/index.js
+++ b/src/components/outlines/editor/index.js
@@ -41,11 +41,11 @@ export default ( React, ...behaviours ) => reactStamp( React ).compose({
 
       content = ContentState.createFromBlockArray( convertFromRaw( this.props.value ) );
     } else {
-      const text = 'enter text here';
+      const text = 'First Header';
       content = ContentState.createFromBlockArray([
         new ContentBlock({
           key: genKey(),
-          type: 'unstyled',
+          type: 'header-two',
           text,
           characterList: List( Repeat( CharacterMetadata.EMPTY, text.length ) )
         }),


### PR DESCRIPTION
- reverse c78b92c96f06e0ae8a8cc849a84c54b10d271b45 because using unstyled text at the start of the outline leads to a difficulty trying to get a header in place to kick off a proper outline
- opt for "Chapter One" rather than "Section Header", in an attempt to convey a little more about its intended usage
