### PR TITLE
fix(FABs): add disableTouchRipple={true} to FABs

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -161,7 +161,10 @@ export const App = ( React, ...behaviours ) => reactStamp( React ).compose({
 
         <FlexLayout direction="row">
           <span flex />
-          <FloatingActionButton onClick={e => this._promptForWorld()}>
+          <FloatingActionButton
+            onClick={e => this._promptForWorld()}
+            disableTouchRipple={true}
+          >
             <AddIcon />
           </FloatingActionButton>
           <Prompt

--- a/src/components/characters/list/index.js
+++ b/src/components/characters/list/index.js
@@ -54,7 +54,10 @@ export default reactStamp( React ).compose({
 
         <FlexLayout direction="row">
           <span flex />
-          <FloatingActionButton onClick={e => this._promptForCharacter()}>
+          <FloatingActionButton
+            onClick={e => this._promptForCharacter()}
+            disableTouchRipple={true}
+          >
             <AddIcon />
           </FloatingActionButton>
           <Prompt

--- a/src/components/elements/list/index.js
+++ b/src/components/elements/list/index.js
@@ -128,7 +128,10 @@ export default reactStamp( React ).compose({
 
         <FlexLayout direction="row">
           <span flex />
-          <FloatingActionButton onClick={e => this._promptForElement()}>
+          <FloatingActionButton
+            onClick={e => this._promptForElement()}
+            disableTouchRipple={true}
+          >
             <AddIcon />
           </FloatingActionButton>
           <Prompt

--- a/src/components/outlines/list/index.js
+++ b/src/components/outlines/list/index.js
@@ -56,7 +56,10 @@ export default reactStamp( React ).compose({
 
         <FlexLayout direction="row">
           <span flex />
-          <FloatingActionButton onClick={e => this._promptForOutline()}>
+          <FloatingActionButton
+            onClick={e => this._promptForOutline()}
+            disableTouchRipple={true}
+          >
             <AddIcon />
           </FloatingActionButton>
           <Prompt


### PR DESCRIPTION
- temp fixes reported issues with + FAB in Safari
- https://github.com/callemall/material-ui/issues/2568
- https://github.com/callemall/material-ui/issues/4421
- https://github.com/callemall/material-ui/issues/1396
- https://github.com/callemall/material-ui/issues/1370
